### PR TITLE
WIP: Add the notion of application-level tags

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 JLSO = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 AWSCore = "0.5.5, 0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "Checkpoints"
 uuid = "b4a3413d-e481-5afc-88ff-bdfbd6a50dce"
 authors = "Invenia Technical Computing Corporation"
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 JLSO = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
@@ -22,6 +23,7 @@ julia = "1"
 [extras]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -30,8 +30,10 @@ include("session.jl")
 
 """
     application_tags()
+    application_tags(tags::Pair...)
+    application_tags(::Nothing)
 
-TODO: add docstring
+Returns, changes, or deletes the application-level tags.
 """
 application_tags() = TAGS
 application_tags(::Nothing) = empty!(TAGS)

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -36,7 +36,7 @@ include("session.jl")
 
 Returns, changes, or deletes the application-level tags.
 """
-application_tags() = TAGS
+application_tags() = return TAGS
 application_tags(::Nothing) = empty!(TAGS)
 function application_tags(tags::Pair...)
     for (k, v) in tags

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -24,8 +24,22 @@ __init__() = Memento.register(LOGGER)
 include("handler.jl")
 
 const CHECKPOINTS = Dict{String, Union{Nothing, Handler}}()
+const TAGS = Dict{Symbol, Any}()
 
 include("session.jl")
+
+"""
+    application_tags()
+
+TODO: add docstring
+"""
+application_tags() = TAGS
+function application_tags(tags::Pair...)
+    for (k, v) in tags
+        TAGS[k] = v
+    end
+end
+
 
 """
     available() -> Vector{String}

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -34,6 +34,7 @@ include("session.jl")
 TODO: add docstring
 """
 application_tags() = TAGS
+application_tags(::Nothing) = empty!(TAGS)
 function application_tags(tags::Pair...)
     for (k, v) in tags
         TAGS[k] = v

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -9,6 +9,7 @@ module Checkpoints
 
 using AWSS3
 using Memento
+using OrderedCollections
 using FilePathsBase
 using FilePathsBase: /, join
 using JLSO
@@ -24,7 +25,7 @@ __init__() = Memento.register(LOGGER)
 include("handler.jl")
 
 const CHECKPOINTS = Dict{String, Union{Nothing, Handler}}()
-const TAGS = Dict{Symbol, Any}()
+const TAGS = OrderedDict{Symbol, Any}()
 
 include("session.jl")
 

--- a/src/handler.jl
+++ b/src/handler.jl
@@ -23,9 +23,12 @@ Names with a '.' separators will be used to form subdirectories
 (e.g., "Foo.bar.x" will be saved to "\$prefix/Foo/bar/x.jlso").
 """
 function path(handler::Handler{P}, name::String; tags...) where P
+    isdisjoint(application_tags(), tags) || ArgumentError("application and package tags can not be the same")
+    all_tags = Iterators.flatten(application_tags(), tags)
+
     # Build up a path prefix based on the tags passed in.
-    prefix = Vector{String}(undef, length(tags))
-    for (i, t) in enumerate(tags)
+    prefix = Vector{String}(undef, length(all_tags))
+    for (i, t) in enumerate(all_tags)
         prefix[i] = string(first(t), "=", last(t))
     end
 

--- a/src/handler.jl
+++ b/src/handler.jl
@@ -24,7 +24,7 @@ Names with a '.' separators will be used to form subdirectories
 """
 function path(handler::Handler{P}, name::String; tags...) where P
     isdisjoint(application_tags(), tags) || ArgumentError("application and package tags can not be the same")
-    all_tags = Iterators.flatten(application_tags(), tags)
+    all_tags = collect(Iterators.flatten((application_tags(), tags)))
 
     # Build up a path prefix based on the tags passed in.
     prefix = Vector{String}(undef, length(all_tags))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,8 @@ Distributed.addprocs(5)
             TestPkg.tagscheck(x)
         end
         @test isfile(joinpath(path, "app_tag=d", "package_tag=1", "TestPkg", "tagscheck.jlso"))
+
+        Checkpoints.application_tags(nothing)
     end
 
     if get(ENV, "LIVE", "false") == "true"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Checkpoints
+using Distributed
 using Test
 using AWSCore
 using FilePathsBase
@@ -8,8 +9,11 @@ using Random
 using AWSCore: AWSConfig
 using AWSS3: S3Path, s3_put, s3_list_buckets, s3_create_bucket
 
+Distributed.addprocs(5)
+@everywhere using Checkpoints
+
 @testset "Checkpoints" begin
-    include("testpkg.jl")
+    @everywhere include("testpkg.jl")
 
     x = reshape(collect(1:100), 10, 10)
     y = reshape(collect(101:200), 10, 10)
@@ -34,6 +38,34 @@ using AWSS3: S3Path, s3_put, s3_list_buckets, s3_create_bucket
             @test data[:x] == x
             @test data[:y] == y
         end
+    end
+
+    @testset "Application-level tags" begin
+        @everywhere begin
+            path = "testpath"
+            Checkpoints.config("TestPkg.tagscheck", path)
+        end
+
+        # run without the application-level checkpoints
+        TestPkg.tagscheck(x)
+        @test isfile(joinpath(path, "package_tag=1", "TestPkg", "tagscheck.jlso"))
+
+        # run with the application-level checkpoints
+        for app_tag in ["a", "b"]
+            Checkpoints.application_tags(:app_tag => app_tag)
+            TestPkg.tagscheck(x)
+        end
+        @test isfile(joinpath(path, "app_tag=a", "package_tag=1", "TestPkg", "tagscheck.jlso"))
+
+        # run concurrently with the application-level checkpoints
+        @test Distributed.nworkers() > 1
+        pmap(["a", "b", "c", "d", "e", "f"]) do app_tag
+            Checkpoints.application_tags(:app_tag => app_tag)
+            sleep(rand()) # make sure not overwritten in the meantime
+            @test Checkpoints.application_tags()[:app_tag] == app_tag
+            TestPkg.tagscheck(x)
+        end
+        @test isfile(joinpath(path, "app_tag=d", "package_tag=1", "TestPkg", "tagscheck.jlso"))
     end
 
     if get(ENV, "LIVE", "false") == "true"

--- a/test/testpkg.jl
+++ b/test/testpkg.jl
@@ -5,7 +5,7 @@ using Checkpoints: register, checkpoint, Session
 # We aren't using `@__MODULE__` because that would return TestPkg on 0.6 and Main.TestPkg on 0.7
 const MODULE = "TestPkg"
 
-__init__() = register(MODULE, ["foo", "bar", "baz", "qux_a", "qux_b"])
+__init__() = register(MODULE, ["foo", "bar", "baz", "qux_a", "qux_b", "tagscheck"])
 
 function foo(x::Matrix, y::Matrix)
     # Save multiple variables to 1 foo.jlso file by passing in pairs of variables
@@ -36,6 +36,12 @@ function qux(a::Dict, b::Vector)
         end
 
         checkpoint(sb, b)
+    end
+end
+
+function tagscheck(x)
+    for package_tag in [1, 2, 3]
+        checkpoint(MODULE, "tagscheck", :x => x; package_tag=package_tag)
     end
 end
 


### PR DESCRIPTION
Let's say I have a `ModelPackage` that checkpoints loss after each training iteration.

In the application program I train this model on a number of datasets.

I want to be able to checkpoint loss for each training iteration (done via tags) for each dataset. This is not currently possible, unless I pass teh dataset information (which shouldn't happen) to the `ModelPackage` which then adds additional tags.

This PR solves this issue by introducing application-level tags, that are merged with the existing tags (package-level tags) when checkpointing.