### PR TITLE
Define indexing functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.6"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ContextVariablesX = "6add18c4-b38d-439d-96f6-d6bc489c04c5"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -16,12 +17,14 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 [compat]
 AWSCore = "0.5.5, 0.6"
 AWSS3 = "0.6, 0.7, 0.8"
+Compat = "3.15"
 ContextVariablesX = "0.1.1"
 DataStructures = "0.17, 0.18"
 FilePathsBase = "0.6, 0.7, 0.8, 0.9"
 JLSO = "2"
 Memento = "0.10, 0.11, 0.12, 0.13, 1"
 OrderedCollections = "1.4"
+Tables="1"
 julia = "1"
 
 [extras]
@@ -29,7 +32,8 @@ AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AWSCore", "AWSS3", "Random", "Test"]
+test = ["AWSCore", "AWSS3", "Random", "Tables", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ FilePathsBase = "0.6, 0.7, 0.8, 0.9"
 JLSO = "2"
 Memento = "0.10, 0.11, 0.12, 0.13, 1"
 OrderedCollections = "1.4"
-Tables="1"
+Tables = "1"
 julia = "1"
 
 [extras]

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -8,6 +8,7 @@ the ability to configure how those checkpoints save data externally
 module Checkpoints
 
 using AWSS3
+using Compat # for contains (julia v1.5)
 using ContextVariablesX
 using DataStructures: DefaultDict
 using FilePathsBase
@@ -28,6 +29,7 @@ const CHECKPOINTS = Dict{String, Union{Nothing, Handler}}()
 @contextvar CONTEXT_TAGS::Tuple{Vararg{Pair{Symbol, Any}}} = Tuple{}()
 
 include("session.jl")
+include("indexing.jl")
 include("deprecated.jl")
 
 """

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -17,7 +17,10 @@ using JLSO
 using Memento
 using OrderedCollections
 
-export checkpoint, with_checkpoint_tags
+export checkpoint, with_checkpoint_tags  # creating stuff
+# indexing stuff
+export IndexEntry, index_checkpoint_files
+export checkpoint_name, checkpoint_path, prefixes, tags
 
 const LOGGER = getlogger(@__MODULE__)
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,0 +1,86 @@
+"""
+    CheckpointOutput
+
+This is a index entry describing the output file from a checkpoint.
+You can retrieve a list of these from a folder full of such outputs, using
+[`index_checkpoint_files`](@ref).
+
+For accessing details of the CheckpointOutput the following helpers are provided:
+[`path`](@ref), [`name`](@ref), [`groups`](@ref), [`tags`](@ref).
+Further: `getproperty` is overloaded so that you can access the value of the tag `:foo` via
+`x.foo`.
+"""
+struct CheckpointOutput{P<:AbstractPath}
+    path::P
+    name::AbstractString
+    groups::NTuple{<:Any, AbstractString}
+    tags::NTuple{<:Any, Pair{Symbol, <:AbstractString}}
+end
+
+path(x::CheckpointOutput) = getfield(x, :path)
+name(x::CheckpointOutput) = getfield(x, :name)
+groups(x::CheckpointOutput) = getfield(x, :groups)
+tags(x::CheckpointOutput) = getfield(x, :tags)
+_tag_names(x::CheckpointOutput) = first.(tags(x))
+
+#Tables.columnnames(x::CheckpointOutput) = propertynames(x)
+Base.propertynames(x::CheckpointOutput) =  [:groups, :name, _tag_names(x)..., :path]
+
+function Base.getproperty(x::CheckpointOutput, name::Symbol)
+    inds = findall(==(name)∘first, tags(x))
+    if length(inds) > 1
+        error(
+            "The checkpoint was tagged with $name multiple times (positions $inds). " *
+            "you thus can not use the getproperty shorthand to check its tag, as we don't" *
+            "know which you mean. Use the `tags` function instead."
+        )
+    elseif length(inds) == 0
+        if hasfield(CheckpointOutput, name)
+            # as long as we don't have a tag with one of the field names we pass it through
+            return getfield(x, name)
+        else
+            error(
+                "The checkpoint does not have the tag $name. It has tags: $(_tag_names(x))"
+            )
+        end
+    else  # tag found
+        _, val = only(tags(x)[inds])
+        return val
+    end
+end
+
+
+"""
+    index_checkpoint_files(dir)
+
+Constructs a index for all the files output by checkpoints located within  `dir`.
+This index tells you their, name, path, tags, etc.
+See [`CheckpointOutput`](@ref) for full information on what is recorded.
+
+Handily, a `Vector{CheckpointOutput}` is a valid [Tables.jl Table][1]. This means you can
+do `DataFrame(index_checkpoint_files(dir))` and get a nice easy to work with [DataFrame][2].
+
+You can also work with it directly, say you wanted to get all checkpoints files for
+`forecasts` with the tag `model="Stage1"`. This would be something like:
+```julia
+[path(x) for x in index_checkpoint_files(dir) if x.name=="forecast" && x.model=="Stage1"]
+```
+
+1: https://github.com/JuliaData/Tables.jl
+2: https://github.com/JuliaData/DataFrames.jl
+"""
+function index_checkpoint_files(dir::AbstractPath)
+    map(Iterators.filter(==("jlso") ∘ extension, walkpath(root))) do path
+        name = filename(path)
+        relpath = relative(path, dir)
+        segments = relpath.segments[1:end-1]
+        groups = filter(!contains("="), segments)
+        tags = map(filter(contains("="), segments)) do seg
+            tag, val = split(seg, "="; limit=2)
+            return Symbol(tag)=>val
+        end
+        return CheckpointOutput(path, name, groups, tags)
+    end
+end
+
+index_checkpoint_files(dir) = index_checkpoint_files(Path(dir))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,32 +1,94 @@
 """
-    CheckpointOutput
+    IndexEntry(checkpoint_path, [checkpoint_name, prefixes, tags])
 
-This is a index entry describing the output file from a checkpoint.
+This is an index entry describing the output file from a checkpoint.
 You can retrieve a list of these from a folder full of such outputs, using
 [`index_checkpoint_files`](@ref).
 
-For accessing details of the CheckpointOutput the following helpers are provided:
-[`path`](@ref), [`name`](@ref), [`groups`](@ref), [`tags`](@ref).
+For accessing details of the IndexEntry the following helpers are provided:
+[`checkpoint_path`](@ref), [`checkpoint_name`](@ref), [`prefixes`](@ref), [`tags`](@ref).
 Further: `getproperty` is overloaded so that you can access the value of the tag `:foo` via
 `x.foo`.
 """
-struct CheckpointOutput{P<:AbstractPath}
-    path::P
-    name::AbstractString
-    groups::NTuple{<:Any, AbstractString}
+struct IndexEntry{P<:AbstractPath}
+    checkpoint_path::P
+    checkpoint_name::AbstractString
+    prefixes::NTuple{<:Any, AbstractString}
     tags::NTuple{<:Any, Pair{Symbol, <:AbstractString}}
 end
 
-path(x::CheckpointOutput) = getfield(x, :path)
-name(x::CheckpointOutput) = getfield(x, :name)
-groups(x::CheckpointOutput) = getfield(x, :groups)
-tags(x::CheckpointOutput) = getfield(x, :tags)
-_tag_names(x::CheckpointOutput) = first.(tags(x))
+IndexEntry(file) = IndexEntry(Path(file))
+function IndexEntry(filepath::AbstractPath)
+    isfile(filepath) || throw(DomainError(filepath, "Need an existant file."))
+    # skip any non-tag directories at the start. Note this will be tricked if those have "="
+    # in them but probably not worth handling, unless an issue comes up
+    first_tag_ind = something(findfirst(contains("="), filepath.segments), 1)
+    segments = filepath.segments[first_tag_ind:end-1]
 
-#Tables.columnnames(x::CheckpointOutput) = propertynames(x)
-Base.propertynames(x::CheckpointOutput) =  [:groups, :name, _tag_names(x)..., :path]
+    prefixes = filter(!contains("="), segments)
+    tags = map(filter(contains("="), segments)) do seg
+        tag, val = split(seg, "="; limit=2)
+        return Symbol(tag)=>val
+    end
+    checkpoint_name = filename(filepath)
+    return IndexEntry(filepath, checkpoint_name, prefixes, tags)
+end
 
-function Base.getproperty(x::CheckpointOutput, name::Symbol)
+
+"""
+    checkpoint_path(x::IndexEntry)
+
+The checkpoint_path to the checkpoint output file.
+For example `S3Path("s3::/mybucket/tag1=a/tag2=b/group1/group2/forecasts.jlso)`.
+"""
+checkpoint_path(x::IndexEntry) = getfield(x, :checkpoint_path)
+
+"""
+    checkpoint_name(x::IndexEntry)
+
+The checkpoint_name of the checkpoint output file.
+If the checkpoint was saved used `checkpoint(Forecasters, "forecasts", ...)` then it's
+`checkpoint_name` is `"forecasts"`.
+"""
+checkpoint_name(x::IndexEntry) = getfield(x, :checkpoint_name)
+
+"""
+    prefixes(x::IndexEntry)
+
+The prefixes of the checkpoint output file. This is a tuple of any prefixes specified.
+If the checkpoint was saved used `checkpoint(Forecasters, "forecasts", ...)` then it's
+`prefixes` are `("Forecasters",)`. Generally in practice there are either one matching the
+module the checkpoint was declared in (as in the previous example), or zero if it wasn't
+specified (as in `checkpoint("forecasts",...)`). If it was saved as
+`checkpoint("Foo.Bar", "forecasts.jlso")` then prefixed will return `("Foo", "Bar")`.
+"""
+prefixes(x::IndexEntry) = getfield(x, :prefixes)
+
+"""
+    tags(x::IndexEntry)
+
+All tags and there values of the checkpoint. This is a collection of pairs.
+For example if the checkpoint was saved using:
+```julia
+with_tag(:sim_now=>DateTime(2000,1,1,9,00), grid=ERCOT) do
+    checkpoint(Forecasters, "forecasts", ...)`
+end
+```
+Then `tags(x)` would return: `(:sim_now="2000-01-01T09:00:00", :grid=>"ERCOT")`.
+
+Note that if the tags are unique, then their values call also be accessed via a
+`getproperty` overload, e.g as `x.sim_now` or `x.grid`.
+"""
+tags(x::IndexEntry) = getfield(x, :tags)
+
+_tag_names(x::IndexEntry) = first.(tags(x))
+
+#Tables.columnnames(x::IndexEntry) = propertynames(x)
+function Base.propertynames(x::IndexEntry)
+    return [:prefixes, :checkpoint_name, _tag_names(x)..., :checkpoint_path]
+end
+
+function Base.getproperty(x::IndexEntry, name::Symbol)
     inds = findall(==(name)∘first, tags(x))
     if length(inds) > 1
         error(
@@ -35,8 +97,7 @@ function Base.getproperty(x::CheckpointOutput, name::Symbol)
             "know which you mean. Use the `tags` function instead."
         )
     elseif length(inds) == 0
-        if hasfield(CheckpointOutput, name)
-            # as long as we don't have a tag with one of the field names we pass it through
+        if hasfield(IndexEntry, name)
             return getfield(x, name)
         else
             error(
@@ -44,8 +105,16 @@ function Base.getproperty(x::CheckpointOutput, name::Symbol)
             )
         end
     else  # tag found
-        _, val = only(tags(x)[inds])
-        return val
+        if hasfield(IndexEntry, name)  #also is a field, so lets error
+            error(
+                "$name is both a tag, and a field of the index entry itself. use the " *
+                "function $name(x) to get the index entry field, or work with `tags(x)` " *
+                "for the field"
+            )
+        else
+            _, val = only(tags(x)[inds])
+            return val
+        end
     end
 end
 
@@ -54,32 +123,24 @@ end
     index_checkpoint_files(dir)
 
 Constructs a index for all the files output by checkpoints located within  `dir`.
-This index tells you their, name, path, tags, etc.
-See [`CheckpointOutput`](@ref) for full information on what is recorded.
+This index tells you their checkpoint_name, checkpoint_path, tags, etc.
+See [`IndexEntry`](@ref) for full information on what is recorded.
 
-Handily, a `Vector{CheckpointOutput}` is a valid [Tables.jl Table][1]. This means you can
+Handily, a `Vector{IndexEntry}` is a valid [Tables.jl Table][1]. This means you can
 do `DataFrame(index_checkpoint_files(dir))` and get a nice easy to work with [DataFrame][2].
 
 You can also work with it directly, say you wanted to get all checkpoints files for
 `forecasts` with the tag `model="Stage1"`. This would be something like:
 ```julia
-[path(x) for x in index_checkpoint_files(dir) if x.name=="forecast" && x.model=="Stage1"]
+[checkpoint_path(x) for x in index_checkpoint_files(dir) if x.checkpoint_name=="forecast" && x.model=="Stage1"]
 ```
 
 1: https://github.com/JuliaData/Tables.jl
 2: https://github.com/JuliaData/DataFrames.jl
 """
 function index_checkpoint_files(dir::AbstractPath)
-    map(Iterators.filter(==("jlso") ∘ extension, walkpath(root))) do path
-        name = filename(path)
-        relpath = relative(path, dir)
-        segments = relpath.segments[1:end-1]
-        groups = filter(!contains("="), segments)
-        tags = map(filter(contains("="), segments)) do seg
-            tag, val = split(seg, "="; limit=2)
-            return Symbol(tag)=>val
-        end
-        return CheckpointOutput(path, name, groups, tags)
+    map(Iterators.filter(==("jlso") ∘ extension, walkpath(dir))) do checkpoint_path
+        return IndexEntry(checkpoint_path)
     end
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -10,8 +10,8 @@ For accessing details of the IndexEntry the following helpers are provided:
 Further: `getproperty` is overloaded so that you can access the value of the tag `:foo` via
 `x.foo`.
 """
-struct IndexEntry{P<:AbstractPath}
-    checkpoint_path::P
+struct IndexEntry
+    checkpoint_path::AbstractPath
     checkpoint_name::AbstractString
     prefixes::NTuple{<:Any, AbstractString}
     tags::NTuple{<:Any, Pair{Symbol, <:AbstractString}}

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,1 +1,43 @@
-@test istable
+@testset "indexing" begin
+    @testset "normal use case" begin
+        mktempdir() do path
+            Checkpoints.config("TestPkg.bar", path)
+            TestPkg.bar([1,2,3])
+
+            index = index_checkpoint_files(path)
+            @test Tables.istable(Tables.columntable(index))
+            @test length(index) == 1
+            entry = only(index)
+            @test tags(entry) == (:date=>"2017-01-01",)
+            @test entry.date == "2017-01-01"
+            @test prefixes(entry) == ("TestPkg",)
+            @test checkpoint_name(entry) == "bar"
+            @test ==(
+                checkpoint_path(entry),
+                Path(joinpath(path, "date=2017-01-01", "TestPkg", "bar.jlso"))
+            )
+        end
+    end
+
+    @testset "clashing tags" begin
+        mktempdir() do path
+            Checkpoints.config("TestPkg.bar", path)
+            with_checkpoint_tags(:tags=>"clash", :a=>"a1", :b=>"b1", :a=>"a2") do
+                TestPkg.bar([1,2,3])
+            end
+
+            index = index_checkpoint_files(path)
+            @test_throws ErrorException Tables.istable(Tables.columntable(index))
+            @test length(index) == 1
+            entry = only(index)
+            @test ==(
+                tags(entry),
+                (:tags=>"clash", :a=>"a1", :b=>"b1", :a=>"a2", :date=>"2017-01-01",)
+            )
+            @test entry.date == "2017-01-01"
+
+            @test_throws ErrorException entry.a
+            @test_throws ErrorException entry.tags
+        end
+    end
+end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,0 +1,1 @@
+@test istable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Checkpoints
+using Compat # for only
 using Distributed
 using Test
 using AWSCore

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using AWSCore
 using FilePathsBase
 using JLSO
 using Random
+using Tables: istable
 
 using AWSCore: AWSConfig
 using AWSS3: S3Path, s3_put, s3_list_buckets, s3_create_bucket
@@ -121,6 +122,8 @@ Distributed.addprocs(5)
             end
         end
     end
+
+    include("indexing.jl")
 
     if get(ENV, "LIVE", "false") == "true"
         @testset "S3 handler" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using AWSCore
 using FilePathsBase
 using JLSO
 using Random
-using Tables: istable
+using Tables: Tables
 
 using AWSCore: AWSConfig
 using AWSS3: S3Path, s3_put, s3_list_buckets, s3_create_bucket


### PR DESCRIPTION
This is to make it easy to work with the output of checkpointing.
No mode adhock `walkdir` or use of Glob.jl.
Increased robustness against the addition of new tags, or reordering of tags.

TODO:
 
- [x] bikeshed over names (this will want to export all of its field access helpers, it would be annoying if they clashed too often with other exports)
- [x] document field access helpers
- [x] tests