### PR TITLE
Add functions to check enabled checkpoints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpoints"
 uuid = "b4a3413d-e481-5afc-88ff-bdfbd6a50dce"
 authors = "Invenia Technical Computing Corporation"
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -18,7 +18,7 @@ using Memento
 using OrderedCollections
 
 export checkpoint, with_checkpoint_tags  # creating stuff
-export enabled
+export enabled_checkpoints
 # indexing stuff
 export IndexEntry, index_checkpoint_files
 export checkpoint_name, checkpoint_path, prefixes, tags
@@ -70,13 +70,11 @@ Returns a vector of all available (registered) checkpoints.
 available() = collect(keys(CHECKPOINTS))
 
 """
-    enabled() -> Vector{String}
+    enabled_checkpoints() -> Vector{String}
 
 Returns a vector of all enabled ([`config`](@ref)ured) checkpoints.
 """
-enabled() = filter(_isenabled, available())
-
-_isenabled(name) = CHECKPOINTS[name] !== nothing
+enabled_checkpoints() = filter(k -> CHECKPOINTS[k] !== nothing, available())
 
 """
     checkpoint([prefix], name, data)

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -18,6 +18,7 @@ using Memento
 using OrderedCollections
 
 export checkpoint, with_checkpoint_tags  # creating stuff
+export enabled
 # indexing stuff
 export IndexEntry, index_checkpoint_files
 export checkpoint_name, checkpoint_path, prefixes, tags
@@ -73,16 +74,9 @@ available() = collect(keys(CHECKPOINTS))
 
 Returns a vector of all enabled ([`config`](@ref)ured) checkpoints.
 """
-enabled() = filter(is_enabled, available())
+enabled() = filter(_isenabled, available())
 
-"""
-    is_enabled(name) -> Bool
-    is_enabled(names...) -> Bool
-
-Returns `true` if the checkpoint `name`(s) are [`config`](@ref)ured.
-"""
-is_enabled(name) = haskey(CHECKPOINTS, name) && CHECKPOINTS[name] !== nothing
-is_enabled(names...) = all(is_enabled.(names))
+_isenabled(name) = CHECKPOINTS[name] !== nothing
 
 """
     checkpoint([prefix], name, data)

--- a/src/Checkpoints.jl
+++ b/src/Checkpoints.jl
@@ -69,6 +69,22 @@ Returns a vector of all available (registered) checkpoints.
 available() = collect(keys(CHECKPOINTS))
 
 """
+    enabled() -> Vector{String}
+
+Returns a vector of all enabled ([`config`](@ref)ured) checkpoints.
+"""
+enabled() = filter(is_enabled, available())
+
+"""
+    is_enabled(name) -> Bool
+    is_enabled(names...) -> Bool
+
+Returns `true` if the checkpoint `name`(s) are [`config`](@ref)ured.
+"""
+is_enabled(name) = haskey(CHECKPOINTS, name) && CHECKPOINTS[name] !== nothing
+is_enabled(names...) = all(is_enabled.(names))
+
+"""
     checkpoint([prefix], name, data)
     checkpoint([prefix], name, data::Pair...)
     checkpoint([prefix], name, data::Dict)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,18 +19,14 @@ Distributed.addprocs(5)
 
     @testset "enabled" begin
         mktempdir() do path
+            @test Checkpoints.enabled() == []
             Checkpoints.register(["c1", "c2"])
             @test Checkpoints.enabled() == []
 
-            @test !Checkpoints.is_enabled("c1")
             Checkpoints.config("c1", path)
-            @test Checkpoints.is_enabled("c1")
             @test Checkpoints.enabled() == ["c1"]
 
-            @test !Checkpoints.is_enabled("c1", "c2")
             Checkpoints.config("c2", path)
-            @test Checkpoints.is_enabled("c1", "c2")
-
             @test Checkpoints.enabled() == ["c1", "c2"]
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,15 +19,15 @@ Distributed.addprocs(5)
 
     @testset "enabled" begin
         mktempdir() do path
-            @test Checkpoints.enabled() == []
-            Checkpoints.register(["c1", "c2"])
-            @test Checkpoints.enabled() == []
+            @test enabled_checkpoints() == []
+            Checkpoints.register(["c1", "c2", "c3"])
+            @test enabled_checkpoints() == []
 
             Checkpoints.config("c1", path)
-            @test Checkpoints.enabled() == ["c1"]
+            @test enabled_checkpoints() == ["c1"]
 
             Checkpoints.config("c2", path)
-            @test Checkpoints.enabled() == ["c1", "c2"]
+            @test enabled_checkpoints() == ["c1", "c2"]
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,24 @@ Distributed.addprocs(5)
 @testset "Checkpoints" begin
     @everywhere include("testpkg.jl")
 
+    @testset "enabled" begin
+        mktempdir() do path
+            Checkpoints.register(["c1", "c2"])
+            @test Checkpoints.enabled() == []
+
+            @test !Checkpoints.is_enabled("c1")
+            Checkpoints.config("c1", path)
+            @test Checkpoints.is_enabled("c1")
+            @test Checkpoints.enabled() == ["c1"]
+
+            @test !Checkpoints.is_enabled("c1", "c2")
+            Checkpoints.config("c2", path)
+            @test Checkpoints.is_enabled("c1", "c2")
+
+            @test Checkpoints.enabled() == ["c1", "c2"]
+        end
+    end
+
     x = reshape(collect(1:100), 10, 10)
     y = reshape(collect(101:200), 10, 10)
     a = collect(1:10)


### PR DESCRIPTION
This PR adds two functions:

1. `is_enabled(name)`: returns `true` if the checkpoint `name` has been `config`ured.
1. `enabled()`: returns a vector of all enabled (`config`ured) checkpoints.

I think both would be useful for users.