### PR TITLE
Update test dependency from AWSCore to AWS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpoints"
 uuid = "b4a3413d-e481-5afc-88ff-bdfbd6a50dce"
 authors = "Invenia Technical Computing Corporation"
-version = "0.3.11"
+version = "0.3.12"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
@@ -16,7 +16,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 AWS = "1"
-AWSS3 = "0.6, 0.7, 0.8, 0.9"
+AWSS3 = "0.8, 0.9"
 Compat = "3.15"
 ContextVariablesX = "0.1.1"
 DataStructures = "0.17, 0.18"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
-AWSCore = "0.5.5, 0.6"
+AWS = "1"
 AWSS3 = "0.6, 0.7, 0.8, 0.9"
 Compat = "3.15"
 ContextVariablesX = "0.1.1"
@@ -28,7 +28,7 @@ Tables = "1"
 julia = "1"
 
 [extras]
-AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
+AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -36,4 +36,4 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AWSCore", "AWSS3", "Random", "Tables", "Test"]
+test = ["AWS", "AWSS3", "Random", "Tables", "Test"]


### PR DESCRIPTION
AWS.jl is now the way most things access AWS. We are in the process of upgrading the rest of the Invenia packages as well.