### PR TITLE
Don't check for isfile for each file in index_checkpoint_files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpoints"
 uuid = "b4a3413d-e481-5afc-88ff-bdfbd6a50dce"
 authors = "Invenia Technical Computing Corporation"
-version = "0.3.12"
+version = "0.3.13"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -18,8 +18,10 @@ struct IndexEntry
 end
 
 IndexEntry(file) = IndexEntry(Path(file))
-function IndexEntry(filepath::AbstractPath)
-    isfile(filepath) || throw(DomainError(filepath, "Need an existant file."))
+function IndexEntry(filepath::AbstractPath, check_exists=false)
+    if check_exists
+        isfile(filepath) || throw(DomainError(filepath, "Need an existant file."))
+    end
     # skip any non-tag directories at the start. Note this will be tricked if those have "="
     # in them but probably not worth handling, unless an issue comes up
     first_tag_ind = something(findfirst(contains("="), filepath.segments), 1)
@@ -139,8 +141,9 @@ You can also work with it directly, say you wanted to get all checkpoints files 
 2: https://github.com/JuliaData/DataFrames.jl
 """
 function index_checkpoint_files(dir::AbstractPath)
+    isdir(dir) || throw(DomainError(dir, "Need an existing directory."))
     map(Iterators.filter(==("jlso") ∘ extension, walkpath(dir))) do checkpoint_path
-        return IndexEntry(checkpoint_path)
+        return IndexEntry(checkpoint_path, check_exists=false)
     end
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -19,9 +19,6 @@ end
 
 IndexEntry(file) = IndexEntry(Path(file))
 function IndexEntry(filepath::AbstractPath, check_exists=false)
-    if check_exists
-        isfile(filepath) || throw(DomainError(filepath, "Need an existant file."))
-    end
     # skip any non-tag directories at the start. Note this will be tricked if those have "="
     # in them but probably not worth handling, unless an issue comes up
     first_tag_ind = something(findfirst(contains("="), filepath.segments), 1)
@@ -141,9 +138,9 @@ You can also work with it directly, say you wanted to get all checkpoints files 
 2: https://github.com/JuliaData/DataFrames.jl
 """
 function index_checkpoint_files(dir::AbstractPath)
-    isdir(dir) || throw(DomainError(dir, "Need an existing directory."))
+    isdir(dir) || throw(ArgumentError(dir, "Need an existing directory."))
     map(Iterators.filter(==("jlso") ∘ extension, walkpath(dir))) do checkpoint_path
-        return IndexEntry(checkpoint_path, check_exists=false)
+        return IndexEntry(checkpoint_path)
     end
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -18,7 +18,7 @@ struct IndexEntry
 end
 
 IndexEntry(file) = IndexEntry(Path(file))
-function IndexEntry(filepath::AbstractPath, check_exists=false)
+function IndexEntry(filepath::AbstractPath)
     # skip any non-tag directories at the start. Note this will be tricked if those have "="
     # in them but probably not worth handling, unless an issue comes up
     first_tag_ind = something(findfirst(contains("="), filepath.segments), 1)


### PR DESCRIPTION
The function `index_checkpoint_files` constructs an `IndexEntry` for each path returned by `walkpath`. This constructor checks for `isfile`, which seems redundant. Having this check undoes the speedups in AWSS3 v0.9. It makes more sense to check if `index_checkpoint_files` is run on a directory that exists. 

Alternatively, the check can be on by default but disabled in `index_checkpoint_files`, if there's a use for `IndexEntry` beyond that function.

On a directory with ~3108 files, removing the check results in a 75X speedup. Compare
```
0.816813 seconds (1.63 M allocations: 91.930 MiB, 4.05% gc time, 4.53% compilation time)
```
vs
```
60.230441 seconds (4.78 M allocations: 285.371 MiB, 0.16% gc time, 0.06% compilation time)
```