### PR TITLE
Make IndexEntry take a base_dir so prefixes and tags can be correct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpoints"
 uuid = "b4a3413d-e481-5afc-88ff-bdfbd6a50dce"
 authors = "Invenia Technical Computing Corporation"
-version = "0.3.15"
+version = "0.3.16"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -24,7 +24,6 @@ struct IndexEntry
     tags::NTuple{<:Any, Pair{Symbol, <:AbstractString}}
 end
 
-IndexEntry(file, base_dir) = IndexEntry(Path(file), Path(base_dir))
 function IndexEntry(filepath::AbstractPath, base_dir)
     segments = relpath(dirname(filepath), base_dir).segments
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,9 +1,16 @@
 """
-    IndexEntry(checkpoint_path, [checkpoint_name, prefixes, tags])
+    IndexEntry(checkpoint_path, base_dir)
+    IndexEntry(checkpoint_path, checkpoint_name, prefixes, tags)
 
 This is an index entry describing the output file from a checkpoint.
 You can retrieve a list of these from a folder full of such outputs, using
-[`index_checkpoint_files`](@ref).
+[`index_checkpoint_files`](@ref), this is the normal way that `IndexEntry`'s are created.
+
+Internally, it is constructed either directly, specifying all of the `checkpoint_path`,
+`checkpoint_name`, `prefixes`, and `tags`.
+Or (more usually) by passing in the `checkpoint_path` and the `base_dir` that that path is
+relative to; then all the `checkpoint_name`, `prefixes` and `tags` can be extracted from the
+path.
 
 For accessing details of the IndexEntry the following helpers are provided:
 [`checkpoint_path`](@ref), [`checkpoint_name`](@ref), [`prefixes`](@ref), [`tags`](@ref).
@@ -17,12 +24,9 @@ struct IndexEntry
     tags::NTuple{<:Any, Pair{Symbol, <:AbstractString}}
 end
 
-IndexEntry(file) = IndexEntry(Path(file))
-function IndexEntry(filepath::AbstractPath)
-    # skip any non-tag directories at the start. Note this will be tricked if those have "="
-    # in them but probably not worth handling, unless an issue comes up
-    first_tag_ind = something(findfirst(contains("="), filepath.segments), 1)
-    segments = filepath.segments[first_tag_ind:end-1]
+IndexEntry(file, base_dir) = IndexEntry(Path(file), Path(base_dir))
+function IndexEntry(filepath::AbstractPath, base_dir)
+    segments = relpath(dirname(filepath), base_dir).segments
 
     prefixes = filter(!contains("="), segments)
     tags = map(filter(contains("="), segments)) do seg
@@ -153,7 +157,7 @@ You can also work with it directly, say you wanted to get all checkpoints files 
 function index_checkpoint_files(dir::AbstractPath)
     isdir(dir) || throw(ArgumentError("Need an existing directory."))
     map(Iterators.filter(==("jlso") ∘ extension, walkpath(dir))) do checkpoint_path
-        return IndexEntry(checkpoint_path)
+        return IndexEntry(checkpoint_path, dir)
     end
 end
 
@@ -167,7 +171,7 @@ Same as [`index_checkpoint_files`] except not restricted to files created by Che
 """
 function index_files(dir::AbstractPath)
     map(Iterators.filter(isfile, walkpath(dir))) do path
-        return IndexEntry(path)
+        return IndexEntry(path, dir)
     end
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -22,10 +22,10 @@
 
     @testset "Searching within a nontrivial directory" begin
         # https://github.com/invenia/Checkpoints.jl/issues/39
-        mktempdir() do outer_path
+        mktempdir(SystemPath) do outer_path
             # This path is tricky, it is more than 1 folder deep
             # and it has `=` in bits that are not tags
-            path = mkdir(joinpath(Path(outer_path),"a","b=1","c"); recursive=true)
+            path = mkdir(joinpath(outer_path,"a","b=1","c"); recursive=true)
             Checkpoints.config("TestPkg.bar", path)
             TestPkg.bar([1,2,3])
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -25,7 +25,7 @@
         mktempdir() do outer_path
             # This path is tricky, it is more than 1 folder deep
             # and it has `=` in bits that are not tags
-            path = mkdir(joinpath(outer_path,"a","b=1","c"); recursive=true)
+            path = mkdir(joinpath(Path(outer_path),"a","b=1","c"); recursive=true)
             Checkpoints.config("TestPkg.bar", path)
             TestPkg.bar([1,2,3])
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -25,7 +25,7 @@
         mktempdir() do outer_path
             # This path is tricky, it is more than 1 folder deep
             # and it has `=` in bits that are not tags
-            path = mkdir(joinpath(mktempdir(Path),"a","b=1","c"); recursive=true)
+            path = mkdir(joinpath(outer_path,"a","b=1","c"); recursive=true)
             Checkpoints.config("TestPkg.bar", path)
             TestPkg.bar([1,2,3])
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -20,6 +20,23 @@
         end
     end
 
+    @testset "Searching within a nontrivial directory" begin
+        # https://github.com/invenia/Checkpoints.jl/issues/39
+        mktempdir() do outer_path
+            # This path is tricky, it is more than 1 folder deep
+            # and it has `=` in bits that are not tags
+            path = mkdir(joinpath(mktempdir(Path),"a","b=1","c"); recursive=true)
+            Checkpoints.config("TestPkg.bar", path)
+            TestPkg.bar([1,2,3])
+
+            index = index_checkpoint_files(path)
+            entry = only(index)
+            @test tags(entry) == (:date=>"2017-01-01",)
+            @test prefixes(entry) == ("TestPkg",)
+            @test checkpoint_name(entry) == "bar"
+        end
+    end
+
     @testset "files not saved by Checkpoints.jl" begin
         mktempdir(SystemPath) do path
             Checkpoints.config("TestPkg.bar", path)


### PR DESCRIPTION
closes #39 

Right now the `base_dir` directory is required.
I kinda think it is fine because noone should be constructing `IndexEntry`'s directly anyway